### PR TITLE
Authenticate client if no auth

### DIFF
--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -222,6 +222,8 @@ class SOCKS5Connection:
             auth_reply = SOCKS5AuthReply.loads(data)
             if auth_reply.method == SOCKS5AuthMethod.USERNAME_PASSWORD:
                 self._state = SOCKS5State.CLIENT_WAITING_FOR_USERNAME_PASSWORD
+            elif auth_reply.method == SOCKS5AuthMethod.NO_AUTH_REQUIRED:
+                self._state = SOCKS5State.CLIENT_AUTHENTICATED
             return auth_reply
 
         if self._state == SOCKS5State.SERVER_VERIFY_USERNAME_PASSWORD:

--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -94,7 +94,7 @@ class SOCKS5UsernamePasswordReply(typing.NamedTuple):
 
     @classmethod
     def loads(cls, data: bytes) -> "SOCKS5UsernamePasswordReply":
-        return cls(success=data == b"\x00")
+        return cls(success=data == b"\x01\x00")
 
 
 class SOCKS5Request(typing.NamedTuple):

--- a/tests/test_socks5.py
+++ b/tests/test_socks5.py
@@ -87,6 +87,20 @@ def test_socks5_auth_reply_malformed(data: bytes) -> None:
         conn.receive_data(data)
 
 
+def test_socks5_no_auth_required_reply_sets_client_authenticated_state() -> None:
+    conn = SOCKS5Connection()
+    request_methods = [
+        SOCKS5AuthMethod.NO_AUTH_REQUIRED,
+        SOCKS5AuthMethod.USERNAME_PASSWORD,
+        SOCKS5AuthMethod.GSSAPI,
+    ]
+
+    conn.authenticate(request_methods)
+    _ = conn.receive_data(b"\x05" + SOCKS5AuthMethod.NO_AUTH_REQUIRED)
+
+    assert conn.state == SOCKS5State.CLIENT_AUTHENTICATED
+
+
 def test_socks5_auth_username_password_requires_connect_waiting() -> None:
     conn = SOCKS5Connection()
     with pytest.raises(ProtocolError):

--- a/tests/test_socks5.py
+++ b/tests/test_socks5.py
@@ -100,7 +100,7 @@ def test_socks5_auth_username_password_success() -> None:
     conn.receive_data(b"\x05" + SOCKS5AuthMethod.USERNAME_PASSWORD)
     conn.authenticate_username_password(b"username", b"password")
     assert conn.data_to_send() == b"\x01\x08username\x08password"
-    conn.receive_data(b"\x00")
+    conn.receive_data(b"\x01\x00")
     assert conn.state == SOCKS5State.CLIENT_AUTHENTICATED
 
 
@@ -129,7 +129,7 @@ def authenticated_conn() -> SOCKS5Connection:
     conn.receive_data(b"\x05" + SOCKS5AuthMethod.USERNAME_PASSWORD)
     conn.authenticate_username_password(b"username", b"password")
     conn.data_to_send()
-    conn.receive_data(b"\x00")
+    conn.receive_data(b"\x01\x00")
     return conn
 
 


### PR DESCRIPTION
Fixes #27 

Also fixes incorrect literal binary used to check for successful authentication.