### PR TITLE
Check import sorting, lint examples/

### DIFF
--- a/examples/example_socks4.py
+++ b/examples/example_socks4.py
@@ -1,4 +1,5 @@
 import socket
+
 from socksio import socks4
 
 

--- a/examples/example_socks4a.py
+++ b/examples/example_socks4a.py
@@ -1,4 +1,5 @@
 import socket
+
 from socksio import socks4
 
 

--- a/examples/example_socks5.py
+++ b/examples/example_socks5.py
@@ -1,4 +1,5 @@
 import socket
+
 from socksio import socks5
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 nox.options.stop_on_first_error = True
 
-source_files = ("socksio", "tests", "noxfile.py")
+source_files = ("socksio", "tests/", "noxfile.py", "examples/")
 
 
 @nox.session()
@@ -20,9 +20,12 @@ def lint(session):
 @nox.session(reuse_venv=True)
 def check(session):
     session.install(
-        "black", "flake8", "flake8-bugbear", "flake8-comprehensions", "mypy"
+        "black", "flake8", "flake8-bugbear", "flake8-comprehensions", "mypy", "isort"
     )
 
+    session.run(
+        "isort", "--project=socksio", "--recursive", "--check-only", *source_files
+    )
     session.run("black", "--check", "--diff", "--target-version=py36", *source_files)
     session.run("flake8", *source_files)
     session.run("mypy", "--strict", "socksio")

--- a/socksio/__init__.py
+++ b/socksio/__init__.py
@@ -2,12 +2,12 @@
 
 from .exceptions import ProtocolError, SOCKSError
 from .socks4 import (
+    SOCKS4ARequest,
     SOCKS4Command,
     SOCKS4Connection,
     SOCKS4Reply,
     SOCKS4ReplyCode,
     SOCKS4Request,
-    SOCKS4ARequest,
 )
 from .socks5 import (
     SOCKS5AType,

--- a/socksio/compat.py
+++ b/socksio/compat.py
@@ -7,7 +7,6 @@ removing 2.7 specific code.
 import functools
 import typing
 
-
 if hasattr(functools, "singledispatchmethod"):  # pragma: nocover
     singledispatchmethod = functools.singledispatchmethod  # type: ignore
 else:

--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -1,6 +1,7 @@
 import enum
 import typing
 
+from .compat import singledispatchmethod
 from .exceptions import ProtocolError
 from .utils import (
     AddressType,
@@ -8,7 +9,6 @@ from .utils import (
     encode_address,
     split_address_port_from_string,
 )
-from .compat import singledispatchmethod
 
 
 class SOCKS5AuthMethod(bytes, enum.Enum):

--- a/socksio/utils.py
+++ b/socksio/utils.py
@@ -1,8 +1,8 @@
 import enum
 import functools
+import re
 import socket
 import typing
-import re
 
 if typing.TYPE_CHECKING:
     from socksio.socks5 import SOCKS5AType  # pragma: nocover

--- a/tests/test_socks4.py
+++ b/tests/test_socks4.py
@@ -2,12 +2,12 @@ import pytest
 
 from socksio import (
     ProtocolError,
+    SOCKS4ARequest,
     SOCKS4Command,
     SOCKS4Connection,
     SOCKS4Reply,
     SOCKS4ReplyCode,
     SOCKS4Request,
-    SOCKS4ARequest,
     SOCKSError,
 )
 


### PR DESCRIPTION
Previously we weren't checking import order in CI so now that is done with `--check-only`.
Also applied linting to the `examples/` directory.