### PR TITLE
Allow hosts and ports as str or bytes in `from_address` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- `from_address` methods now accept `str` or `bytes` objects
+[#46](https://github.com/sethmlarson/socksio/pull/46).
+
 ## 0.2.0 (2020-01-28)
 
 ### Changed
@@ -12,7 +19,8 @@ the different connection classes [#37](https://github.com/sethmlarson/socksio/pu
 ### Fixed
 
 - SOCKS5 prefixing domain name with length [#29](https://github.com/sethmlarson/socksio/pull/29).
-- SOCKS5 requiring authentication even if no authentication method is specified [#30](https://github.com/sethmlarson/socksio/pull/30).
+- SOCKS5 requiring authentication even if no authentication method is specified
+[#30](https://github.com/sethmlarson/socksio/pull/30).
 
 ## 0.1.0 (2019-12-03)
 

--- a/socksio/_types.py
+++ b/socksio/_types.py
@@ -1,0 +1,3 @@
+import typing as t
+
+StrOrBytes = t.Union[str, bytes]

--- a/socksio/_types.py
+++ b/socksio/_types.py
@@ -1,3 +1,3 @@
-import typing as t
+import typing
 
-StrOrBytes = t.Union[str, bytes]
+StrOrBytes = typing.Union[str, bytes]

--- a/socksio/socks4.py
+++ b/socksio/socks4.py
@@ -1,6 +1,7 @@
 import enum
 import typing
 
+from ._types import StrOrBytes
 from .exceptions import ProtocolError, SOCKSError
 from .utils import (
     AddressType,
@@ -46,7 +47,7 @@ class SOCKS4Request(typing.NamedTuple):
     def from_address(
         cls,
         command: SOCKS4Command,
-        address: typing.Union[str, typing.Tuple[str, int]],
+        address: typing.Union[StrOrBytes, typing.Tuple[StrOrBytes, int]],
         user_id: typing.Optional[bytes] = None,
     ) -> "SOCKS4Request":
         """Convenience class method to build an instance from command and address.
@@ -63,11 +64,11 @@ class SOCKS4Request(typing.NamedTuple):
         Raises:
             SOCKSError: If a domain name or IPv6 address was supplied.
         """
-        if isinstance(address, str):
+        if isinstance(address, (str, bytes)):
             address, port = split_address_port_from_string(address)
         else:
             address, port = address
-            if isinstance(port, str):
+            if isinstance(port, (str, bytes)):
                 port = int(port)
 
         atype, encoded_addr = encode_address(address)
@@ -126,7 +127,7 @@ class SOCKS4ARequest(typing.NamedTuple):
     def from_address(
         cls,
         command: SOCKS4Command,
-        address: typing.Union[str, typing.Tuple[str, int]],
+        address: typing.Union[StrOrBytes, typing.Tuple[StrOrBytes, int]],
         user_id: typing.Optional[bytes] = None,
     ) -> "SOCKS4ARequest":
         """Convenience class method to build an instance from command and address.
@@ -140,11 +141,11 @@ class SOCKS4ARequest(typing.NamedTuple):
         Returns:
             A SOCKS4ARequest instance.
         """
-        if isinstance(address, str):
+        if isinstance(address, (str, bytes)):
             address, port = split_address_port_from_string(address)
         else:
             address, port = address
-            if isinstance(port, str):
+            if isinstance(port, (str, bytes)):
                 port = int(port)
 
         atype, encoded_addr = encode_address(address)

--- a/socksio/socks4.py
+++ b/socksio/socks4.py
@@ -7,7 +7,7 @@ from .utils import (
     AddressType,
     decode_address,
     encode_address,
-    split_address_port_from_string,
+    get_address_port_tuple_from_address,
 )
 
 
@@ -64,13 +64,7 @@ class SOCKS4Request(typing.NamedTuple):
         Raises:
             SOCKSError: If a domain name or IPv6 address was supplied.
         """
-        if isinstance(address, (str, bytes)):
-            address, port = split_address_port_from_string(address)
-        else:
-            address, port = address
-            if isinstance(port, (str, bytes)):
-                port = int(port)
-
+        address, port = get_address_port_tuple_from_address(address)
         atype, encoded_addr = encode_address(address)
         if atype != AddressType.IPV4:
             raise SOCKSError(
@@ -141,13 +135,7 @@ class SOCKS4ARequest(typing.NamedTuple):
         Returns:
             A SOCKS4ARequest instance.
         """
-        if isinstance(address, (str, bytes)):
-            address, port = split_address_port_from_string(address)
-        else:
-            address, port = address
-            if isinstance(port, (str, bytes)):
-                port = int(port)
-
+        address, port = get_address_port_tuple_from_address(address)
         atype, encoded_addr = encode_address(address)
         return cls(command=command, addr=encoded_addr, port=port, user_id=user_id)
 

--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -1,6 +1,7 @@
 import enum
 import typing
 
+from ._types import StrOrBytes
 from .compat import singledispatchmethod
 from .exceptions import ProtocolError
 from .utils import (
@@ -167,7 +168,9 @@ class SOCKS5CommandRequest(typing.NamedTuple):
 
     @classmethod
     def from_address(
-        cls, command: SOCKS5Command, address: typing.Union[str, typing.Tuple[str, int]]
+        cls,
+        command: SOCKS5Command,
+        address: typing.Union[StrOrBytes, typing.Tuple[StrOrBytes, int]],
     ) -> "SOCKS5CommandRequest":
         """Convenience class method to build an instance from command and address.
 
@@ -182,11 +185,11 @@ class SOCKS5CommandRequest(typing.NamedTuple):
         Raises:
             SOCKSError: If a domain name or IPv6 address was supplied.
         """
-        if isinstance(address, str):
+        if isinstance(address, (str, bytes)):
             address, port = split_address_port_from_string(address)
         else:
             address, port = address
-            if isinstance(port, str):
+            if isinstance(port, (str, bytes)):
                 port = int(port)
 
         atype, encoded_addr = encode_address(address)

--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -8,7 +8,7 @@ from .utils import (
     AddressType,
     decode_address,
     encode_address,
-    split_address_port_from_string,
+    get_address_port_tuple_from_address,
 )
 
 
@@ -185,13 +185,7 @@ class SOCKS5CommandRequest(typing.NamedTuple):
         Raises:
             SOCKSError: If a domain name or IPv6 address was supplied.
         """
-        if isinstance(address, (str, bytes)):
-            address, port = split_address_port_from_string(address)
-        else:
-            address, port = address
-            if isinstance(port, (str, bytes)):
-                port = int(port)
-
+        address, port = get_address_port_tuple_from_address(address)
         atype, encoded_addr = encode_address(address)
         return cls(
             command=command,

--- a/socksio/utils.py
+++ b/socksio/utils.py
@@ -4,6 +4,8 @@ import re
 import socket
 import typing
 
+from ._types import StrOrBytes
+
 if typing.TYPE_CHECKING:
     from socksio.socks5 import SOCKS5AType  # pragma: nocover
 
@@ -30,8 +32,9 @@ class AddressType(enum.Enum):
 
 
 @functools.lru_cache(maxsize=64)
-def encode_address(addr: str) -> typing.Tuple[AddressType, bytes]:
+def encode_address(addr: StrOrBytes) -> typing.Tuple[AddressType, bytes]:
     """Determines the type of address and encodes it into the format SOCKS expects"""
+    addr = addr.decode() if isinstance(addr, bytes) else addr
     try:
         return AddressType.IPV6, socket.inet_pton(socket.AF_INET6, addr)
     except OSError:
@@ -53,12 +56,13 @@ def decode_address(address_type: AddressType, encoded_addr: bytes) -> str:
         return encoded_addr.decode()
 
 
-def split_address_port_from_string(address: str) -> typing.Tuple[str, int]:
+def split_address_port_from_string(address: StrOrBytes) -> typing.Tuple[str, int]:
     """Returns a tuple (address: str, port: int) from an address string with a port
     i.e. '127.0.0.1:8080', '[0:0:0:0:0:0:0:1]:3080' or 'localhost:8080'.
 
     Note no validation is done on the domain or IP itself.
     """
+    address = address.decode() if isinstance(address, bytes) else address
     match = re.match(IP_V6_WITH_PORT_REGEX, address)
     if match:
         address, str_port = match.group("address"), match.group("port")

--- a/socksio/utils.py
+++ b/socksio/utils.py
@@ -83,11 +83,13 @@ def get_address_port_tuple_from_address(
     address: typing.Union[StrOrBytes, typing.Tuple[StrOrBytes, int]]
 ) -> typing.Tuple[str, int]:
     """Returns an (address, port) from an address string-like or tuple."""
-    if isinstance(address, (str, bytes)):
-        address, port = split_address_port_from_string(address)
-    else:
+    if isinstance(address, tuple):
         address, port = address
+        if isinstance(address, bytes):
+            address = address.decode()
         if isinstance(port, (str, bytes)):
             port = int(port)
+    else:
+        address, port = split_address_port_from_string(address)
 
     return address, port

--- a/socksio/utils.py
+++ b/socksio/utils.py
@@ -77,3 +77,17 @@ def split_address_port_from_string(address: StrOrBytes) -> typing.Tuple[str, int
             "address with the port as a suffix, i.e. `127.0.0.1:3080`, "
             "`[0:0:0:0:0:0:0:1]:3080` or `localhost:3080`"
         ) from None
+
+
+def get_address_port_tuple_from_address(
+    address: typing.Union[StrOrBytes, typing.Tuple[StrOrBytes, int]]
+) -> typing.Tuple[str, int]:
+    """Returns an (address, port) from an address string-like or tuple."""
+    if isinstance(address, (str, bytes)):
+        address, port = split_address_port_from_string(address)
+    else:
+        address, port = address
+        if isinstance(port, (str, bytes)):
+            port = int(port)
+
+    return address, port

--- a/tests/test_socks4.py
+++ b/tests/test_socks4.py
@@ -18,6 +18,9 @@ from socksio import (
         (("127.0.0.1", 3080), b"\x7f\x00\x00\x01", 3080),
         (("127.0.0.1", "3080"), b"\x7f\x00\x00\x01", 3080),
         ("127.0.0.1:8080", b"\x7f\x00\x00\x01", 8080),
+        ((b"127.0.0.1", 3080), b"\x7f\x00\x00\x01", 3080),
+        ((b"127.0.0.1", b"3080"), b"\x7f\x00\x00\x01", 3080),
+        (b"127.0.0.1:8080", b"\x7f\x00\x00\x01", 8080),
     ],
 )
 def test_socks4request_from_address(address, expected_address, expected_port) -> None:
@@ -56,6 +59,9 @@ def test_socks4request_from_address_dump_raises_if_no_user_id():
         (("127.0.0.1", 3080), b"\x7f\x00\x00\x01", 3080),
         (("127.0.0.1", "3080"), b"\x7f\x00\x00\x01", 3080),
         ("127.0.0.1:8080", b"\x7f\x00\x00\x01", 8080),
+        ((b"127.0.0.1", 3080), b"\x7f\x00\x00\x01", 3080),
+        ((b"127.0.0.1", b"3080"), b"\x7f\x00\x00\x01", 3080),
+        (b"127.0.0.1:8080", b"\x7f\x00\x00\x01", 8080),
     ],
 )
 def test_socks4arequest_from_address(address, expected_address, expected_port) -> None:

--- a/tests/test_socks5.py
+++ b/tests/test_socks5.py
@@ -48,6 +48,15 @@ def test_socks5atype_unknown_address_type_raises() -> None:
             b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
             3080,
         ),
+        ((b"127.0.0.1", 3080), SOCKS5AType.IPV4_ADDRESS, b"\x7f\x00\x00\x01", 3080),
+        ((b"127.0.0.1", b"3080"), SOCKS5AType.IPV4_ADDRESS, b"\x7f\x00\x00\x01", 3080),
+        (b"127.0.0.1:8080", SOCKS5AType.IPV4_ADDRESS, b"\x7f\x00\x00\x01", 8080),
+        (
+            "[0:0:0:0:0:0:0:1]:3080",
+            SOCKS5AType.IPV6_ADDRESS,
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+            3080,
+        ),
     ],
 )
 def test_socks5commandrequest_from_address(

--- a/tests/test_socks5.py
+++ b/tests/test_socks5.py
@@ -52,7 +52,7 @@ def test_socks5atype_unknown_address_type_raises() -> None:
         ((b"127.0.0.1", b"3080"), SOCKS5AType.IPV4_ADDRESS, b"\x7f\x00\x00\x01", 3080),
         (b"127.0.0.1:8080", SOCKS5AType.IPV4_ADDRESS, b"\x7f\x00\x00\x01", 8080),
         (
-            "[0:0:0:0:0:0:0:1]:3080",
+            b"[0:0:0:0:0:0:0:1]:3080",
             SOCKS5AType.IPV6_ADDRESS,
             b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
             3080,


### PR DESCRIPTION
While trying to use it I found having to decode the host annoying.