### PR TITLE
enhance: fix bytearray might be passed into lru_cached function

### DIFF
--- a/socksio/socks4.py
+++ b/socksio/socks4.py
@@ -193,6 +193,9 @@ class SOCKS4Reply(typing.NamedTuple):
         Raises:
             ProtocolError: If the data does not match the spec.
         """
+        if isinstance(data, bytearray):
+            data = bytes(data)
+
         if len(data) != 8 or data[0:1] != b"\x00":
             raise ProtocolError("Malformed reply")
 

--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -250,6 +250,9 @@ class SOCKS5Reply(typing.NamedTuple):
         Raises:
             ProtocolError: If the data does not match the spec.
         """
+        if isinstance(data, bytearray):
+            data = bytes(data)
+
         if data[0:1] != b"\x05":
             raise ProtocolError("Malformed reply")
 


### PR DESCRIPTION
Most type checkers will fit `bytearray` into `bytes` automatically. However, the former is hashable but the later is **not hashable**. Our `decode_address` is a `lru_cache` function and **requires hashable inputs**. This will trigger an exception says "unhashable type: 'bytearray'".

Example:

```py
from socksio.socks5 import SOCKS5Reply

data = bytearray(b'\x05\x00\x00\x01\x7f\x00\x00\x01\x1e\xd2')
SOCKS5Reply.loads(bytes(data))  # OK
SOCKS5Reply.loads(data)         # ValueError

```