### PR TITLE
Unpin flit-core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=2"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
The current version of flit-core is 3.9.0, and I'm creating this patch for use packaging this project within [nixpkgs](https://github.com/NixOS/nixpkgs), which provides the most recent version.