### PR TITLE
fix unhashable bytearray exception

### DIFF
--- a/socksio/socks5.py
+++ b/socksio/socks5.py
@@ -259,7 +259,7 @@ class SOCKS5Reply(typing.NamedTuple):
             return cls(
                 reply_code=SOCKS5ReplyCode(data[1:2]),
                 atype=atype,
-                addr=decode_address(AddressType.from_socks5_atype(atype), data[4:-2]),
+                addr=decode_address(AddressType.from_socks5_atype(atype), bytes(data[4:-2])),
                 port=int.from_bytes(data[-2:], byteorder="big"),
             )
         except ValueError as exc:


### PR DESCRIPTION
i encountered this exception while using httpx with a socks5 proxy
``` python
  File "C:...\test.py", line 675, in test
    r = await client.get("https://httpbin.org/")
  File "C:\...\lib\site-packages\httpx\_client.py", line 1768, in get
    return await self.request(
  File "C:\...\lib\site-packages\httpx\_client.py", line 1540, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "C:\...\lib\site-packages\httpx\_client.py", line 1629, in send
    response = await self._send_handling_auth(
  File "C:\...\lib\site-packages\httpx\_client.py", line 1657, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "C:\...\lib\site-packages\httpx\_client.py", line 1694, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "C:\...\lib\site-packages\httpx\_client.py", line 1730, in _send_single_request
    response = await transport.handle_async_request(request)
  File "C:\...\lib\site-packages\httpx\_transports\default.py", line 394, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "C:\...\lib\site-packages\httpcore\_async\connection_pool.py", line 216, in handle_async_request
    raise exc from None
  File "C:\...\lib\site-packages\httpcore\_async\connection_pool.py", line 196, in handle_async_request
    response = await connection.handle_async_request(
  File "C:\...\lib\site-packages\httpcore\_async\socks_proxy.py", line 296, in handle_async_request
    raise exc
  File "C:\...\lib\site-packages\httpcore\_async\socks_proxy.py", line 245, in handle_async_request
    await _init_socks5_connection(**kwargs)
  File "C:\...\lib\site-packages\httpcore\_async\socks_proxy.py", line 97, in _init_socks5_connection
    response = conn.receive_data(incoming_bytes)
  File "C:\...\lib\site-packages\socksio\socks5.py", line 381, in receive_data
    reply = SOCKS5Reply.loads(data)
  File "C:\...\lib\site-packages\socksio\socks5.py", line 261, in loads
    addr=decode_address(AddressType.from_socks5_atype(atype), data[4:-2]),
TypeError: unhashable type: 'bytearray'
```

using this code

``` python
 client = httpx.AsyncClient(proxy=f"socks5://user:password@domain:port")
 try:
	r = await client.get("https://httpbin.org/ip")
	print(r.text)
 except Exception as ex:
	print(traceback.format_exc())
```
not really sure which package to blame for this error, but converting data to bytes type before calling "from_socks5_atype" fixed this
